### PR TITLE
Support Scala 2.11

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -3,7 +3,7 @@ name := "allure-scalatest"
 
 organization := "ru.yandex.qatools.allure"
 
-version := "1.4.0-SNAPSHOT"
+version := "1.5.0-SNAPSHOT"
 
 description := "Scalatest adapter for Allure framework."
 

--- a/build.sbt
+++ b/build.sbt
@@ -26,15 +26,9 @@ scmInfo := Some(
 organizationName := "Yandex LLC"
 
 /* scala versions and options */
-scalaVersion := "2.10.3"
+scalaVersion := "2.11.8"
 
-crossScalaVersions := Seq(
-  "2.8.0", "2.8.1", "2.8.2",
-  "2.9.0", "2.9.0-1",
-  "2.9.1", "2.9.1-1",
-  "2.9.2",
-  "2.9.3"
-)
+crossScalaVersions := Seq()
 
 // These options will be used for *all* versions.
 scalacOptions ++= Seq(

--- a/build.sbt
+++ b/build.sbt
@@ -72,7 +72,7 @@ resolvers +=
 
 libraryDependencies ++= Seq (
   "org.scalatest" %% "scalatest" % "2.2.6",
-  "ru.yandex.qatools.allure" % "allure-java-aspects" % "1.4.0",
+  "ru.yandex.qatools.allure" % "allure-java-aspects" % "1.4.23",
   "org.mockito" % "mockito-all" % "1.9.5" % "test"
 )
 

--- a/build.sbt
+++ b/build.sbt
@@ -46,7 +46,9 @@ scalacOptions ++= Seq(
 
 // These language flags will be used only for 2.10.x.
 // Uncomment those you need, or if you hate SIP-18, all of them.
-scalacOptions <++= scalaVersion map { sv =>
+scalacOptions ++= {
+  val sv = scalaVersion.value
+
   if (sv startsWith "2.10") List(
     "-Xverify",
     "-Ywarn-all",
@@ -87,7 +89,8 @@ offline := false
 /* publishing */
 publishMavenStyle := true
 
-publishTo <<= version { (v: String) =>
+publishTo := {
+  val v = version.value
   val nexus = "https://oss.sonatype.org/"
   if (v.trim.endsWith("SNAPSHOT")) Some(
     "snapshots" at nexus + "content/repositories/snapshots"

--- a/build.sbt
+++ b/build.sbt
@@ -73,7 +73,7 @@ resolvers +=
 libraryDependencies ++= Seq (
   "org.scalatest" %% "scalatest" % "2.2.6",
   "ru.yandex.qatools.allure" % "allure-java-aspects" % "1.4.23",
-  "org.mockito" % "mockito-all" % "1.9.5" % "test"
+  "org.mockito" % "mockito-core" % "2.4.2" % "test"
 )
 
 /* testing */

--- a/build.sbt
+++ b/build.sbt
@@ -69,7 +69,7 @@ resolvers +=
   "Sonatype OSS Snapshots" at "https://oss.sonatype.org/content/repositories/snapshots"
 
 libraryDependencies ++= Seq (
-  "org.scalatest" % "scalatest_2.10" % "2.1.4",
+  "org.scalatest" %% "scalatest" % "2.2.6",
   "ru.yandex.qatools.allure" % "allure-java-aspects" % "1.4.0",
   "org.mockito" % "mockito-all" % "1.9.5" % "test"
 )

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.12.4
+sbt.version=0.13.13

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,6 +1,6 @@
 //addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.8.4")
 
-addSbtPlugin("com.timushev.sbt" % "sbt-updates" % "0.1.0")
+//addSbtPlugin("com.timushev.sbt" % "sbt-updates" % "0.1.0")
 
 addSbtPlugin("com.github.mpeltonen" % "sbt-idea" % "1.5.1")
 

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,6 +1,10 @@
 //addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.8.4")
 
-//addSbtPlugin("com.timushev.sbt" % "sbt-updates" % "0.1.0")
+resolvers += Resolver.url(
+  "rtimush/sbt-plugin-snapshots",
+  new URL("https://dl.bintray.com/rtimush/sbt-plugin-snapshots/"))(
+  Resolver.ivyStylePatterns)
+addSbtPlugin("com.timushev.sbt" % "sbt-updates" % "0.3.0")
 
 addSbtPlugin("com.github.mpeltonen" % "sbt-idea" % "1.5.1")
 

--- a/src/test/scala/ru/yandex/qatools/allure/scalatest/AllureReporterSpec.scala
+++ b/src/test/scala/ru/yandex/qatools/allure/scalatest/AllureReporterSpec.scala
@@ -5,7 +5,9 @@ import ru.yandex.qatools.allure.Allure
 import org.mockito.Mockito._
 import org.scalatest.events._
 import ru.yandex.qatools.allure.events._
-import org.mockito.Matchers.{eq => eql, any}
+import org.mockito.ArgumentCaptor
+import org.mockito.ArgumentMatchers._
+import org.mockito.Mockito._
 import org.scalatest.events.TestStarting
 import org.scalatest.events.SuiteStarting
 import org.scalatest.events.TestSucceeded
@@ -15,9 +17,9 @@ import scala.Some
 import java.util.UUID
 
 class AllureReporterSpec extends FlatSpec with BeforeAndAfter {
-  
+
   var allure: Allure = _
-  
+
   var reporter: AllureReporter = _
 
   val testUuid = "some-uid"
@@ -33,9 +35,9 @@ class AllureReporterSpec extends FlatSpec with BeforeAndAfter {
     allure = mock(classOf[Allure])
     reporter = spy(new AllureReporter)
     reporter.setLifecycle(allure)
-    doReturn(testUuid).when(reporter).getSuiteUuid(any(classOf[String]))
+    when(reporter.getSuiteUuid(anyString())).thenReturn(testUuid)
   }
-  
+
   "AllureReporter" should "fire Allure TestSuiteStarted event on suite start" in {
     reporter.apply(SuiteStarting(
       testOrdinal,
@@ -49,9 +51,10 @@ class AllureReporterSpec extends FlatSpec with BeforeAndAfter {
       "",
       testTimestamp
     ))
-    verify(allure).fire(eql(new TestSuiteStartedEvent(testUuid, testSuiteId)))
+
+    verify(allure).fire(new TestSuiteStartedEvent(testUuid, testSuiteId))
   }
-  
+
   it should "fire TestSuiteFinished event on suite finish" in {
     reporter.apply(SuiteCompleted(
       testOrdinal,
@@ -66,9 +69,9 @@ class AllureReporterSpec extends FlatSpec with BeforeAndAfter {
       "",
       testTimestamp
     ))
-    verify(allure).fire(eql(new TestSuiteFinishedEvent(testUuid)))
+    verify(allure).fire(new TestSuiteFinishedEvent(testUuid))
   }
-  
+
   it should "fire TestCaseStarted event on test case start" in {
     reporter.apply(TestStarting(
       testOrdinal,
@@ -84,9 +87,18 @@ class AllureReporterSpec extends FlatSpec with BeforeAndAfter {
       "",
       testTimestamp
     ))
-    verify(allure).fire(eql(new TestCaseStartedEvent(testUuid, testMethodName)))
+
+    // Mockito had trouble with the TestCaseStartedEvent reference.
+    // Just verify that the reporter didn't pass garbage arguments.
+
+    val captor = ArgumentCaptor.forClass(classOf[TestCaseStartedEvent])
+    verify(allure).fire(captor.capture())
+
+    val event = captor.getValue
+    assert(event.getSuiteUid == testUuid)
+    assert(event.getName == testMethodName)
   }
-  
+
   it should "fire TestCaseFinished event on test case success" in {
     reporter.apply(TestSucceeded(
       testOrdinal,
@@ -104,9 +116,9 @@ class AllureReporterSpec extends FlatSpec with BeforeAndAfter {
       "",
       testTimestamp
     ))
-    verify(allure).fire(eql(new TestCaseFinishedEvent))
+    verify(allure).fire(new TestCaseFinishedEvent)
   }
-  
+
   it should "fire TestCaseFailed event with throwable on test case failure when throwable is present" in {
     reporter.apply(TestFailed(
       testOrdinal,
@@ -126,9 +138,9 @@ class AllureReporterSpec extends FlatSpec with BeforeAndAfter {
       "",
       testTimestamp
     ))
-    verify(allure).fire(eql(new TestCaseFailureEvent().withThrowable(testException)))
+    verify(allure).fire(new TestCaseFailureEvent().withThrowable(testException))
   }
-  
+
   it should "fire TestCaseFailed event with runtime exception having message inside on test case failure when throwable is missing" in {
     reporter.apply(TestFailed(
       testOrdinal,
@@ -150,7 +162,7 @@ class AllureReporterSpec extends FlatSpec with BeforeAndAfter {
     ))
     verify(allure).fire(any(classOf[TestCaseFailureEvent]))
   }
-  
+
   it should "fire TestCaseCanceled event when test case is skipped" in {
     reporter.apply(TestIgnored(
       testOrdinal,
@@ -167,7 +179,7 @@ class AllureReporterSpec extends FlatSpec with BeforeAndAfter {
     ))
     verify(allure).fire(new TestCaseCanceledEvent)
   }
-  
+
   it should "fire TestCasePending event when test case is pending" in {
     reporter.apply(TestPending(
       testOrdinal,
@@ -186,7 +198,7 @@ class AllureReporterSpec extends FlatSpec with BeforeAndAfter {
     ))
     verify(allure).fire(new TestCasePendingEvent)
   }
-  
+
   it should "fire TestCaseCanceled event when test case is canceled" in {
     reporter.apply(TestCanceled(
       testOrdinal,
@@ -208,7 +220,7 @@ class AllureReporterSpec extends FlatSpec with BeforeAndAfter {
     ))
     verify(allure).fire(new TestCaseCanceledEvent)
   }
-    
+
   it should "return uuid on first and subsequent getSuiteUuid calls" in {
     val reporter = new AllureReporter
     val firstUUID = reporter.getSuiteUuid(testSuiteId)
@@ -217,15 +229,15 @@ class AllureReporterSpec extends FlatSpec with BeforeAndAfter {
     assert(firstUUID == secondUUID)
     assert(UUID.fromString(firstUUID).equals(UUID.fromString(secondUUID)))
   }
-  
+
   it should "return empty list when called with any location except TopOfMethod or TopOfClass or None" in {
     val reporter = new AllureReporter
     assert(reporter.getAnnotations(Some(LineInFile(0, ""))).isEmpty)
     assert(reporter.getAnnotations(None).isEmpty)
   }
-  
+
   after {
     verifyNoMoreInteractions(allure)
   }
-  
+
 }


### PR DESCRIPTION
https://github.com/allure-framework/allure-scalatest/issues/9

Ports the package up to:

- allure-java-aspects 1.4.23
- mockito-core 2.4.2 
- sbt 0.13.13
- scala 2.11.8
- scalatest 2.2.6

Removes sbt-updates 0.1.0. build.sbt was modified to conform to recent SBT. AllureReporterSpec had to be modified to pass tests with allure-java-aspects 1.4.23. Cross-compilation of anything but 2.11.8 is removed, as I don't have experience with it.

The version of allure-scalatest is bumped up to 1.5.0-SNAPSHOT.

This was ported so as to support an internal evaluation of Allure for visualising CI results. We have verified that this ported version of allure-scalatest succeeds in generating a basic ScalaTest report, but have not yet experimented with the Allure-specific annotations.