### PR TITLE
Support scala 2.12.4

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -24,7 +24,7 @@ scmInfo := Some(
 organizationName := "Yandex LLC"
 
 /* scala versions and options */
-scalaVersion := "2.11.8"
+scalaVersion := "2.12.4"
 
 crossScalaVersions := Seq()
 
@@ -35,11 +35,6 @@ scalacOptions ++= Seq(
   "-encoding", "UTF-8"
   // "-Xcheckinit" // for debugging only, see https://github.com/paulp/scala-faq/wiki/Initialization-Order
   // "-optimise"   // this option will slow your build
-)
-
-scalacOptions ++= Seq(
-  "-Yclosure-elim",
-  "-Yinline"
 )
 
 // These language flags will be used only for 2.10.x.
@@ -69,7 +64,7 @@ resolvers +=
   "Sonatype OSS Snapshots" at "https://oss.sonatype.org/content/repositories/snapshots"
 
 libraryDependencies ++= Seq (
-  "org.scalatest" %% "scalatest" % "2.2.6",
+  "org.scalatest" %% "scalatest" % "3.0.4",
   "ru.yandex.qatools.allure" % "allure-java-aspects" % "1.4.23",
   "org.mockito" % "mockito-core" % "2.4.2" % "test"
 )

--- a/src/test/scala/ru/yandex/qatools/allure/scalatest/AllureReporterSpec.scala
+++ b/src/test/scala/ru/yandex/qatools/allure/scalatest/AllureReporterSpec.scala
@@ -232,7 +232,7 @@ class AllureReporterSpec extends FlatSpec with BeforeAndAfter {
 
   it should "return empty list when called with any location except TopOfMethod or TopOfClass or None" in {
     val reporter = new AllureReporter
-    assert(reporter.getAnnotations(Some(LineInFile(0, ""))).isEmpty)
+    assert(reporter.getAnnotations(Some(LineInFile(0, "", None))).isEmpty)
     assert(reporter.getAnnotations(None).isEmpty)
   }
 

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "1.5-SNAPSHOT"
+version in ThisBuild := "1.5-SNAPSHOT-dg"


### PR DESCRIPTION
Moved the compiler version forward to 2.12.4 and scalaTest to 3.0.4. One minor code changed to address an apply function signature change for LineInFile. Removal of scala command line paramaters that are no longer valid.

[output.txt](https://github.com/allure-framework/allure-scalatest/files/1623219/output.txt)
